### PR TITLE
fixed typo in predicate spellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ From [underscore.js][]:
 return filter(obj, negate(cb(predicate)), context);
 
 // With pipes
-return cb(pred) |> _.negate(^) |> _.filter(obj, ^, context);
+return cb(predicate) |> _.negate(^) |> _.filter(obj, ^, context);
 ```
 
 From [ramda.js][].


### PR DESCRIPTION
the refactor example original code uses 'predicate' with full spelling while the hack pipe example only used 'pred'.