### PR TITLE
Add some missing closing parentheses in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ rather than Hack pipes, but this could be changed.
 |`a.map(x=> x + 1)`          |`a.map(x=> x + 1)`          |
 |`a.map(f(?, 0))`            |`a.map(x=> f(x, 0))`        |
 |`a.map(x=> x + x)`          |`a.map(x=> x + x)`          |
-|`a.map(x=> f(x, x))`        |`a.map(x=> f(x, x)`         |
+|`a.map(x=> f(x, x))`        |`a.map(x=> f(x, x))`        |
 |`a.sort((x,y)=> x - y)`     |`a.sort((x,y)=> x - y)`     |
 |`a.sort(f(?, ?, 0))`        |`a.sort((x,y)=> f(x, y, 0))`|
 
@@ -720,7 +720,7 @@ in order to be syntactically valid.
 |`a.map(x=> x + 1)`          |`a.map(+> ^ + 1)`           |
 |`a.map(f(?, 0))`            |`a.map(+> f(^, 0))`         |
 |`a.map(x=> x + x)`          |`a.map(+> ^ + ^)`           |
-|`a.map(x=> f(x, x))`        |`a.map(+> f(^, ^)`          |
+|`a.map(x=> f(x, x))`        |`a.map(+> f(^, ^))`         |
 |`a.sort((x,y)=> x - y)`     |`a.sort(+> ^0 - ^1)`        |
 |`a.sort(f(?, ?, 0))`        |`a.sort(+> f(^0, ^1, 0))`   |
 


### PR DESCRIPTION
I came across two lost closing parentheses, I hope this is the right place to return them.